### PR TITLE
Give auth hooks access to ecto sandbox

### DIFF
--- a/lib/my_app_web/router.ex
+++ b/lib/my_app_web/router.ex
@@ -17,6 +17,10 @@ defmodule MyAppWeb.Router do
     plug :accepts, ["json"]
   end
 
+  @common_on_mount_hooks if Application.compile_env(:my_app, :sql_sandbox),
+                           do: [MyAppWeb.LiveAsyncFeatureTests],
+                           else: []
+
   scope "/", MyAppWeb do
     pipe_through :browser
 
@@ -51,7 +55,8 @@ defmodule MyAppWeb.Router do
     pipe_through [:browser, :redirect_if_user_is_authenticated]
 
     live_session :redirect_if_user_is_authenticated,
-      on_mount: [{MyAppWeb.UserAuth, :redirect_if_user_is_authenticated}] do
+      on_mount:
+        @common_on_mount_hooks ++ [{MyAppWeb.UserAuth, :redirect_if_user_is_authenticated}] do
       live "/users/register", UserRegistrationLive, :new
       live "/users/log_in", UserLoginLive, :new
       live "/users/reset_password", UserForgotPasswordLive, :new
@@ -65,7 +70,7 @@ defmodule MyAppWeb.Router do
     pipe_through [:browser, :require_authenticated_user]
 
     live_session :require_authenticated_user,
-      on_mount: [{MyAppWeb.UserAuth, :ensure_authenticated}] do
+      on_mount: @common_on_mount_hooks ++ [{MyAppWeb.UserAuth, :ensure_authenticated}] do
       live "/users/settings", UserSettingsLive, :edit
       live "/users/settings/confirm_email/:token", UserSettingsLive, :confirm_email
     end
@@ -77,7 +82,7 @@ defmodule MyAppWeb.Router do
     delete "/users/log_out", UserSessionController, :delete
 
     live_session :current_user,
-      on_mount: [{MyAppWeb.UserAuth, :mount_current_user}] do
+      on_mount: @common_on_mount_hooks ++ [{MyAppWeb.UserAuth, :mount_current_user}] do
       live "/users/confirm/:token", UserConfirmationLive, :edit
       live "/users/confirm", UserConfirmationInstructionsLive, :new
     end

--- a/test/features/register_test.exs
+++ b/test/features/register_test.exs
@@ -13,5 +13,7 @@ defmodule Features.RegisterTest do
     |> fill_in("Password", with: "passwordpassword")
     |> click_button("Create an account")
     |> assert_has("#flash-info", text: "Account created")
+    |> visit(~p"/users/settings")
+    |> assert_has("h1", text: "Settings")
   end
 end


### PR DESCRIPTION
Following [this doc update on the Phoenix Ecto repo](https://github.com/phoenixframework/phoenix_ecto/commit/76e5b7f8286c6212db5cabb68934c0ee3758d667)